### PR TITLE
[ssd][refactoring] IOManager Refactoring to adhere to SRP 

### DIFF
--- a/SSDSimulator/SSDSimulator/IOManager.cpp
+++ b/SSDSimulator/SSDSimulator/IOManager.cpp
@@ -1,6 +1,5 @@
 #include "IOManager.h"
 
-#if OUTPUT_REFACTORING
 void IOManager::updateOutputError() {
     output().updateOutputError();
 }
@@ -13,16 +12,6 @@ void IOManager::updateOutputReadSuccess(uint32_t readData) {
     output().updateOutputReadSuccess(readData);
 }
 
-std::ofstream IOManager::openFile(const std::string& filename) {
-    std::ofstream file(filename);
-    if (!file) {
-        throw std::runtime_error("error opening file");
-    }
-    return file;
-}
-#endif
-
-#if NAND_REFACTORING 
 void IOManager::CheckAndCreateNandDataFile() {
     nand().CheckAndCreateNandDataFile();
 }
@@ -46,9 +35,7 @@ void IOManager::CreateNewTempNandFileAndInitForTest() {
 void IOManager::deleteFileIfExists() {
     nand().deleteFileIfExists();
 }
-#endif
 
-#if BUFFER_REFACTORING 
 bool IOManager::forceCreateFiveFreshBufferFiles() {
     return buffer().forceCreateFiveFreshBufferFiles();
 }
@@ -60,7 +47,6 @@ bool IOManager::updateBufferFiles(const std::vector<std::string> buffers) {
 std::vector<std::string> IOManager::getBufferFileList() {
     return buffer().getBufferFileList();
 }
-#endif
 
 
 

--- a/SSDSimulator/SSDSimulator/IOManager.cpp
+++ b/SSDSimulator/SSDSimulator/IOManager.cpp
@@ -1,12 +1,5 @@
 #include "IOManager.h"
 
-void IOManager::CheckAndCreateNandDataFile() {
-    if (nandDataFileExist()) return;
-
-    auto nandDataFile = openFile(NAND_DATA_FILE);
-    FillZeroDataToAllAddresses(nandDataFile);
-}
-
 #if OUTPUT_REFACTORING
 void IOManager::updateOutputError() {
     output().updateOutputError();
@@ -29,114 +22,45 @@ std::ofstream IOManager::openFile(const std::string& filename) {
 }
 #endif
 
+#if NAND_REFACTORING 
+void IOManager::CheckAndCreateNandDataFile() {
+    nand().CheckAndCreateNandDataFile();
+}
+
 void IOManager::ProgramAllDatasToNand(const std::vector<LbaEntry>& lbaTable) {
-    auto nandDataFile = openFile(NAND_DATA_FILE);
-    FillChangeDatasToAllAddresses(nandDataFile, lbaTable);
+    nand().ProgramAllDatasToNand(lbaTable);
 }
 
 void IOManager::ReadAllDatasToInternalBuffer(std::vector<LbaEntry>& lbaTable) {
-    std::ifstream file(NAND_DATA_FILE);
-    std::string line;
-    while (std::getline(file, line)) {
-        if (line.empty()) continue;
-
-        LbaEntry splitDatas;
-        if (false == SplitStringToAddressAndData(line, &splitDatas)) continue;
-        lbaTable.push_back({ splitDatas.address, splitDatas.data });
-    }
+    nand().ReadAllDatasToInternalBuffer(lbaTable);
 }
 
 bool IOManager::SplitStringToAddressAndData(std::string& line, LbaEntry* splitDatas) {
-    std::string addrStr, dataStr;
-    size_t delimiterPos = line.find(SEPARATOR.c_str());
-    if (delimiterPos == std::string::npos) return false;
-
-    addrStr = line.substr(0, delimiterPos);
-    dataStr = line.substr(delimiterPos + 1);
-
-    return SuccessConvertToUINT(splitDatas, addrStr, dataStr);
+    return nand().SplitStringToAddressAndData(line, splitDatas);
 }
 
 void IOManager::CreateNewTempNandFileAndInitForTest() {
-    std::ifstream file(NAND_DATA_FILE);
-    if (!file) {
-        std::vector<LbaEntry> readDatas{};
-        uint32_t initAddress = 0x705FF427;
-        for (uint32_t lba = 0; lba <= maxLbaOfDevice; ++lba) {
-            readDatas.push_back({ lba, initAddress++ });
-        }
-        ProgramAllDatasToNand(readDatas);
-    }
+    nand().CreateNewTempNandFileAndInitForTest();
 }
 
 void IOManager::deleteFileIfExists() {
-    if (std::ifstream(NAND_DATA_FILE)) {
-        std::remove(NAND_DATA_FILE.c_str());
-    }
+    nand().deleteFileIfExists();
 }
+#endif
 
 #if BUFFER_REFACTORING 
 bool IOManager::forceCreateFiveFreshBufferFiles() {
-    //createEmptyBufferFolder();
-    //return createFiveFreshBufferFiles();
     return buffer().forceCreateFiveFreshBufferFiles();
 }
 
 bool IOManager::updateBufferFiles(const std::vector<std::string> buffers) {
-    //createEmptyBufferFolder();
-    //return createFiveBufferFiles(buffers);
     return buffer().updateBufferFiles(buffers);
 }
 
 std::vector<std::string> IOManager::getBufferFileList() {
-    //std::vector<std::string> buffers;
-    //for (const auto& fileName : std::filesystem::directory_iterator(BUFFER_FOLDER)) {
-    //    if (fileName.is_regular_file()) {
-    //        buffers.push_back(removeFolderPathFrom(fileName));
-    //    }
-    //}
-    //return buffers;
     return buffer().getBufferFileList();
 }
 #endif
 
-bool IOManager::nandDataFileExist() {
-    std::ifstream file(NAND_DATA_FILE);
-    if (!file) return false;
-    return true;
-}
 
-void IOManager::FillZeroDataToAllAddresses(std::ofstream& nandDataFile) {
-    for (uint32_t lba = 0; lba <= maxLbaOfDevice; ++lba) {
-        nandDataFile << std::hex << lba;
-        nandDataFile << SEPARATOR;
-        nandDataFile << std::setw(8) << std::setfill('0') << INIT_NAND_DATA;
-        nandDataFile << std::endl;
-    }
-}
-
-void IOManager::FillChangeDatasToAllAddresses(std::ofstream& nandDataFile,
-    const std::vector<LbaEntry>& lbaTable) {
-    for (uint32_t lba = 0; lba <= maxLbaOfDevice; ++lba) {
-        nandDataFile << std::hex << lba;
-        nandDataFile << SEPARATOR;
-        nandDataFile << std::hex << std::setw(8) << std::setfill('0')
-            << lbaTable[lba].data;
-        nandDataFile << std::endl;
-    }
-}
-
-bool IOManager::SuccessConvertToUINT(LbaEntry* splitDatas, std::string& addrStr,
-    std::string& dataStr) {
-    try {
-        (*splitDatas).address = std::stoul(addrStr, nullptr, 16);
-        (*splitDatas).data = std::stoul(dataStr, nullptr, 16);
-    }
-    catch (const std::exception& e) {
-        std::cerr << "Fail convert string to unsigned long :";
-        std::cerr << e.what() << std::endl;
-        return false;
-    }
-    return true;
-}
 

--- a/SSDSimulator/SSDSimulator/IOManager.cpp
+++ b/SSDSimulator/SSDSimulator/IOManager.cpp
@@ -8,18 +8,15 @@ void IOManager::CheckAndCreateNandDataFile() {
 }
 
 void IOManager::updateOutputError() {
-    auto outputFile = openFile(OUTPUT_FILE);
-    outputFile << OUTPUT_ERROR;
+    output().updateOutputError();
 }
 
 void IOManager::updateOutputWriteSuccess() {
-    auto outputFile = openFile(OUTPUT_FILE);
+    output().updateOutputWriteSuccess();
 }
 
 void IOManager::updateOutputReadSuccess(uint32_t readData) {
-    auto outputFile = openFile(OUTPUT_FILE);
-    outputFile << "0x" << std::uppercase << std::hex << std::setw(8)
-        << std::setfill('0') << readData << std::endl;
+    output().updateOutputReadSuccess(readData);
 }
 
 void IOManager::ProgramAllDatasToNand(const std::vector<LbaEntry>& lbaTable) {

--- a/SSDSimulator/SSDSimulator/IOManager.h
+++ b/SSDSimulator/SSDSimulator/IOManager.h
@@ -1,15 +1,5 @@
 #pragma once
-#include <direct.h>
-#include <errno.h>
-#include <sys/types.h>
-
-#include <cstdint>
-#include <filesystem>
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <string>
-#include <vector>
+#include "outputFile.h"
 
 namespace fs = std::filesystem;
 
@@ -22,10 +12,15 @@ class IOManager {
 public:
     IOManager(uint32_t maxLbaOfDevice) : maxLbaOfDevice(maxLbaOfDevice) {}
 
-    void CheckAndCreateNandDataFile();
+    OutputFile& output() { return outputFile; }
+#if 1 /*Output-related functions <-- Need to be gone later*/
     void updateOutputError();
     void updateOutputWriteSuccess();
     void updateOutputReadSuccess(uint32_t readData);
+    // OpenFile 
+#endif
+
+    void CheckAndCreateNandDataFile();
     void ProgramAllDatasToNand(const std::vector<LbaEntry>& lbaTable);
     void ReadAllDatasToInternalBuffer(std::vector<LbaEntry>& lbaTable);
     bool SplitStringToAddressAndData(std::string& line, LbaEntry* splitDatas);
@@ -37,6 +32,8 @@ public:
     std::vector<std::string> getBufferFileList();
 
 private:
+    OutputFile outputFile;
+
     bool nandDataFileExist();
     std::ofstream openFile(const std::string& filename);
     void FillZeroDataToAllAddresses(std::ofstream& nandDataFile);
@@ -58,8 +55,6 @@ private:
     const static uint32_t INIT_NAND_DATA = 0;
 
     const std::string NAND_DATA_FILE = "ssd_nand.txt";
-    const std::string OUTPUT_FILE = "ssd_output.txt";
-    const std::string OUTPUT_ERROR = "ERROR";
     const std::string SEPARATOR = ";";
 
     static const uint32_t NUM_OF_BUFFERS = 5;

--- a/SSDSimulator/SSDSimulator/IOManager.h
+++ b/SSDSimulator/SSDSimulator/IOManager.h
@@ -1,15 +1,13 @@
 #pragma once
 #include "outputFile.h"
 #include "bufferFile.h"
-
-struct LbaEntry {
-    uint32_t address;
-    uint32_t data;
-};
+#include "nandFile.h"
 
 class IOManager {
 public:
-    IOManager(uint32_t maxLbaOfDevice) : maxLbaOfDevice(maxLbaOfDevice) {}
+    IOManager(uint32_t maxLbaOfDevice)  {
+        nand().setDeviceMaxLba(maxLbaOfDevice);
+    }
 
     OutputFile& output() { return outputFile; }
 #if OUTPUT_REFACTORING
@@ -26,32 +24,18 @@ public:
     std::vector<std::string> getBufferFileList();
 #endif
 
+    NandFile& nand() { return nandFile; }
+#if NAND_REFACTORING 
     void CheckAndCreateNandDataFile();
     void ProgramAllDatasToNand(const std::vector<LbaEntry>& lbaTable);
     void ReadAllDatasToInternalBuffer(std::vector<LbaEntry>& lbaTable);
     bool SplitStringToAddressAndData(std::string& line, LbaEntry* splitDatas);
     void CreateNewTempNandFileAndInitForTest();
     void deleteFileIfExists();
+#endif
 
 private:
     OutputFile outputFile;
     BufferFile bufferFile;
-
-    bool nandDataFileExist();
-    void FillZeroDataToAllAddresses(std::ofstream& nandDataFile);
-    void FillChangeDatasToAllAddresses(std::ofstream& nandDataFile,
-        const std::vector<LbaEntry>& lbaTable);
-    bool SuccessConvertToUINT(LbaEntry* splitDatas, std::string& addrStr,
-        std::string& dataStr);
-
-    const uint32_t maxLbaOfDevice;
-    const static uint32_t INIT_NAND_DATA = 0;
-    const std::string NAND_DATA_FILE = "ssd_nand.txt";
-    const std::string SEPARATOR = ";";
-
-#if BUFFER_REFACTORING
-    static const uint32_t NUM_OF_BUFFERS = 5;
-    const std::string BUFFER_FOLDER = "./buffer/";
-    const std::string EMPTY_BUFFER_FILE_SUFFIX = "_empty";
-#endif
+    NandFile nandFile;
 };

--- a/SSDSimulator/SSDSimulator/IOManager.h
+++ b/SSDSimulator/SSDSimulator/IOManager.h
@@ -5,34 +5,25 @@
 
 class IOManager {
 public:
-    IOManager(uint32_t maxLbaOfDevice)  {
-        nand().setDeviceMaxLba(maxLbaOfDevice);
-    }
+    IOManager(uint32_t maxLbaOfDevice) : nandFile(maxLbaOfDevice) {}
 
     OutputFile& output() { return outputFile; }
-#if OUTPUT_REFACTORING
     void updateOutputError();
     void updateOutputWriteSuccess();
     void updateOutputReadSuccess(uint32_t readData);
-    std::ofstream openFile(const std::string& filename);
-#endif
 
     BufferFile& buffer() { return bufferFile; }
-#if BUFFER_REFACTORING 
     bool forceCreateFiveFreshBufferFiles();
     bool updateBufferFiles(const std::vector<std::string> buffers);
     std::vector<std::string> getBufferFileList();
-#endif
 
     NandFile& nand() { return nandFile; }
-#if NAND_REFACTORING 
     void CheckAndCreateNandDataFile();
     void ProgramAllDatasToNand(const std::vector<LbaEntry>& lbaTable);
     void ReadAllDatasToInternalBuffer(std::vector<LbaEntry>& lbaTable);
     bool SplitStringToAddressAndData(std::string& line, LbaEntry* splitDatas);
     void CreateNewTempNandFileAndInitForTest();
     void deleteFileIfExists();
-#endif
 
 private:
     OutputFile outputFile;

--- a/SSDSimulator/SSDSimulator/IOManager.h
+++ b/SSDSimulator/SSDSimulator/IOManager.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "outputFile.h"
-
-namespace fs = std::filesystem;
+#include "bufferFile.h"
 
 struct LbaEntry {
     uint32_t address;
@@ -13,11 +12,18 @@ public:
     IOManager(uint32_t maxLbaOfDevice) : maxLbaOfDevice(maxLbaOfDevice) {}
 
     OutputFile& output() { return outputFile; }
-#if 1 /*Output-related functions <-- Need to be gone later*/
+#if OUTPUT_REFACTORING
     void updateOutputError();
     void updateOutputWriteSuccess();
     void updateOutputReadSuccess(uint32_t readData);
-    // OpenFile 
+    std::ofstream openFile(const std::string& filename);
+#endif
+
+    BufferFile& buffer() { return bufferFile; }
+#if BUFFER_REFACTORING 
+    bool forceCreateFiveFreshBufferFiles();
+    bool updateBufferFiles(const std::vector<std::string> buffers);
+    std::vector<std::string> getBufferFileList();
 #endif
 
     void CheckAndCreateNandDataFile();
@@ -27,37 +33,25 @@ public:
     void CreateNewTempNandFileAndInitForTest();
     void deleteFileIfExists();
 
-    bool forceCreateFiveFreshBufferFiles();
-    bool updateBufferFiles(const std::vector<std::string> buffers);
-    std::vector<std::string> getBufferFileList();
-
 private:
     OutputFile outputFile;
+    BufferFile bufferFile;
 
     bool nandDataFileExist();
-    std::ofstream openFile(const std::string& filename);
     void FillZeroDataToAllAddresses(std::ofstream& nandDataFile);
     void FillChangeDatasToAllAddresses(std::ofstream& nandDataFile,
         const std::vector<LbaEntry>& lbaTable);
     bool SuccessConvertToUINT(LbaEntry* splitDatas, std::string& addrStr,
         std::string& dataStr);
-    
-    bool createFiveBufferFiles(const std::vector<std::string> buffers);
-    bool createFiveFreshBufferFiles();
-    void createEmptyBufferFolder();
-    void createBufferFolder();
-    bool removeAllFilesInFolder();
-    bool createBufferFile(const std::string& fileName);
-    std::string removeFolderPathFrom(const std::filesystem::directory_entry& file);
-    bool fileExists(const std::string fileName);
 
     const uint32_t maxLbaOfDevice;
     const static uint32_t INIT_NAND_DATA = 0;
-
     const std::string NAND_DATA_FILE = "ssd_nand.txt";
     const std::string SEPARATOR = ";";
 
+#if BUFFER_REFACTORING
     static const uint32_t NUM_OF_BUFFERS = 5;
     const std::string BUFFER_FOLDER = "./buffer/";
     const std::string EMPTY_BUFFER_FILE_SUFFIX = "_empty";
+#endif
 };

--- a/SSDSimulator/SSDSimulator/SSDSimulator.vcxproj
+++ b/SSDSimulator/SSDSimulator/SSDSimulator.vcxproj
@@ -145,8 +145,11 @@
     <ClCompile Include="test_ssdCmdWrite.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="bufferFile.h" />
     <ClInclude Include="cmdBuffer.h" />
+    <ClInclude Include="fileIO.h" />
     <ClInclude Include="IOManager.h" />
+    <ClInclude Include="outputFile.h" />
     <ClInclude Include="ssdCmdErase.h" />
     <ClInclude Include="ssdCmdError.h" />
     <ClInclude Include="ssdCmdFlush.h" />

--- a/SSDSimulator/SSDSimulator/SSDSimulator.vcxproj
+++ b/SSDSimulator/SSDSimulator/SSDSimulator.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="cmdBuffer.h" />
     <ClInclude Include="fileIO.h" />
     <ClInclude Include="IOManager.h" />
+    <ClInclude Include="nandFile.h" />
     <ClInclude Include="outputFile.h" />
     <ClInclude Include="ssdCmdErase.h" />
     <ClInclude Include="ssdCmdError.h" />

--- a/SSDSimulator/SSDSimulator/SSDSimulator.vcxproj
+++ b/SSDSimulator/SSDSimulator/SSDSimulator.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="ssdCmdParser.cpp" />
     <ClCompile Include="ssdCmdRead.cpp" />
     <ClCompile Include="ssdCmdWrite.cpp" />
+    <ClCompile Include="ssdSimulator.cpp" />
     <ClCompile Include="test_ssdBuffer.cpp" />
     <ClCompile Include="test_cmdBuffer.cpp" />
     <ClCompile Include="test_ssdCmdErase.cpp" />

--- a/SSDSimulator/SSDSimulator/bufferFile.h
+++ b/SSDSimulator/SSDSimulator/bufferFile.h
@@ -1,0 +1,89 @@
+#pragma once
+#include "fileIo.h"
+
+class BufferFile {
+public:
+    BufferFile() = default;
+
+    bool forceCreateFiveFreshBufferFiles() {
+        createEmptyBufferFolder();
+        return createFiveFreshBufferFiles();
+    }
+
+    bool updateBufferFiles(const std::vector<std::string> buffers) {
+        createEmptyBufferFolder();
+        return createFiveBufferFiles(buffers);
+    }
+
+    std::vector<std::string> getBufferFileList() {
+        std::vector<std::string> buffers;
+        for (const auto& fileName : std::filesystem::directory_iterator(BUFFER_FOLDER)) {
+            if (fileName.is_regular_file()) {
+                buffers.push_back(removeFolderPathFrom(fileName));
+            }
+        }
+        return buffers;
+    }
+
+private:
+    static const uint32_t NUM_OF_BUFFERS = 5;
+    const std::string BUFFER_FOLDER = "./buffer/";
+    const std::string EMPTY_BUFFER_FILE_SUFFIX = "_empty";
+
+    bool createFiveBufferFiles(const std::vector<std::string> buffers) {
+        for (auto bufferFileName : buffers) {
+            if (!createBufferFile(BUFFER_FOLDER + bufferFileName)) return false;
+        }
+        return true;
+    }
+
+    bool createFiveFreshBufferFiles() {
+        for (unsigned int buffer = 1; buffer <= NUM_OF_BUFFERS; buffer++) {
+            std::string fileName = std::to_string(buffer) + EMPTY_BUFFER_FILE_SUFFIX;
+            if (!createBufferFile(BUFFER_FOLDER + fileName)) return false;
+        }
+        return true;
+    }
+
+    void createEmptyBufferFolder() {
+        createBufferFolder();
+        removeAllFilesInFolder();
+    }
+
+    void createBufferFolder() {
+        std::filesystem::create_directory(BUFFER_FOLDER);
+    }
+
+    bool removeAllFilesInFolder() {
+        try {
+            for (const auto& entry : fs::directory_iterator(BUFFER_FOLDER)) {
+                if (entry.is_regular_file()) {
+                    fs::remove(entry.path());
+                }
+            }
+            return true;
+        }
+        catch (const fs::filesystem_error& e) {
+            std::cerr << "Error removing files: " << e.what() << std::endl;
+            return false;
+        }
+    }
+
+    bool createBufferFile(const std::string & fileName) {
+        std::ofstream file(fileName, std::ios::trunc);  // trunc: overwrite if exists
+        return file.is_open();
+    }
+
+    std::string removeFolderPathFrom(const std::filesystem::directory_entry & file) {
+        return file.path().filename().string();
+    }
+
+    bool fileExists(const std::string fileName) {
+        fs::path filePath = fs::path(BUFFER_FOLDER) / fileName;
+        if (!fs::exists(filePath)) {
+            std::cerr << "File not found: " << filePath << std::endl;
+            return false;
+        }
+        return true;
+    }
+};

--- a/SSDSimulator/SSDSimulator/fileIO.h
+++ b/SSDSimulator/SSDSimulator/fileIO.h
@@ -6,3 +6,9 @@
 #include <iostream>
 #include <string>
 #include <vector>
+
+namespace fs = std::filesystem;
+
+
+#define OUTPUT_REFACTORING (1)
+#define BUFFER_REFACTORING  (1)

--- a/SSDSimulator/SSDSimulator/fileIO.h
+++ b/SSDSimulator/SSDSimulator/fileIO.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>

--- a/SSDSimulator/SSDSimulator/fileIO.h
+++ b/SSDSimulator/SSDSimulator/fileIO.h
@@ -8,8 +8,3 @@
 #include <vector>
 
 namespace fs = std::filesystem;
-
-
-#define OUTPUT_REFACTORING (1)
-#define BUFFER_REFACTORING  (1)
-#define NAND_REFACTORING    (1)

--- a/SSDSimulator/SSDSimulator/fileIO.h
+++ b/SSDSimulator/SSDSimulator/fileIO.h
@@ -12,3 +12,4 @@ namespace fs = std::filesystem;
 
 #define OUTPUT_REFACTORING (1)
 #define BUFFER_REFACTORING  (1)
+#define NAND_REFACTORING    (1)

--- a/SSDSimulator/SSDSimulator/nandFile.h
+++ b/SSDSimulator/SSDSimulator/nandFile.h
@@ -11,13 +11,8 @@ public:
     NandFile() : maxLbaOfDevice(0) {};
     NandFile(uint32_t maxLbaOfDevice) : maxLbaOfDevice(maxLbaOfDevice) {}
 
-    void setDeviceMaxLba(uint32_t deviceMaxLba) {
-        this->maxLbaOfDevice = deviceMaxLba;
-    }
-
     void CheckAndCreateNandDataFile() {
         if (nandDataFileExist()) return;
-
         auto nandDataFile = openFile(NAND_DATA_FILE);
         FillZeroDataToAllAddresses(nandDataFile);
     }
@@ -67,6 +62,7 @@ public:
             std::remove(NAND_DATA_FILE.c_str());
         }
     }
+
 private:
     uint32_t maxLbaOfDevice;
     const static uint32_t INIT_NAND_DATA = 0;

--- a/SSDSimulator/SSDSimulator/nandFile.h
+++ b/SSDSimulator/SSDSimulator/nandFile.h
@@ -8,7 +8,6 @@ struct LbaEntry {
 
 class NandFile {
 public:
-    NandFile() : maxLbaOfDevice(0) {};
     NandFile(uint32_t maxLbaOfDevice) : maxLbaOfDevice(maxLbaOfDevice) {}
 
     void CheckAndCreateNandDataFile() {

--- a/SSDSimulator/SSDSimulator/nandFile.h
+++ b/SSDSimulator/SSDSimulator/nandFile.h
@@ -1,0 +1,123 @@
+#pragma once
+#include "fileIo.h"
+
+struct LbaEntry {
+    uint32_t address;
+    uint32_t data;
+};
+
+class NandFile {
+public:
+    NandFile() : maxLbaOfDevice(0) {};
+    NandFile(uint32_t maxLbaOfDevice) : maxLbaOfDevice(maxLbaOfDevice) {}
+
+    void setDeviceMaxLba(uint32_t deviceMaxLba) {
+        this->maxLbaOfDevice = deviceMaxLba;
+    }
+
+    void CheckAndCreateNandDataFile() {
+        if (nandDataFileExist()) return;
+
+        auto nandDataFile = openFile(NAND_DATA_FILE);
+        FillZeroDataToAllAddresses(nandDataFile);
+    }
+
+    void ProgramAllDatasToNand(const std::vector<LbaEntry>& lbaTable) {
+        auto nandDataFile = openFile(NAND_DATA_FILE);
+        FillChangeDatasToAllAddresses(nandDataFile, lbaTable);
+    }
+
+    void ReadAllDatasToInternalBuffer(std::vector<LbaEntry>& lbaTable) {
+        std::ifstream file(NAND_DATA_FILE);
+        std::string line;
+        while (std::getline(file, line)) {
+            if (line.empty()) continue;
+
+            LbaEntry splitDatas;
+            if (false == SplitStringToAddressAndData(line, &splitDatas)) continue;
+            lbaTable.push_back({ splitDatas.address, splitDatas.data });
+        }
+    }
+
+    bool SplitStringToAddressAndData(std::string& line, LbaEntry* splitDatas) {
+        std::string addrStr, dataStr;
+        size_t delimiterPos = line.find(SEPARATOR.c_str());
+        if (delimiterPos == std::string::npos) return false;
+
+        addrStr = line.substr(0, delimiterPos);
+        dataStr = line.substr(delimiterPos + 1);
+
+        return SuccessConvertToUINT(splitDatas, addrStr, dataStr);
+    }
+
+    void CreateNewTempNandFileAndInitForTest() {
+        std::ifstream file(NAND_DATA_FILE);
+        if (!file) {
+            std::vector<LbaEntry> readDatas{};
+            uint32_t initAddress = 0x705FF427;
+            for (uint32_t lba = 0; lba <= maxLbaOfDevice; ++lba) {
+                readDatas.push_back({ lba, initAddress++ });
+            }
+            ProgramAllDatasToNand(readDatas);
+        }
+    }
+
+    void deleteFileIfExists() {
+        if (std::ifstream(NAND_DATA_FILE)) {
+            std::remove(NAND_DATA_FILE.c_str());
+        }
+    }
+private:
+    uint32_t maxLbaOfDevice;
+    const static uint32_t INIT_NAND_DATA = 0;
+    const std::string NAND_DATA_FILE = "ssd_nand.txt";
+    const std::string SEPARATOR = ";";
+
+    std::ofstream openFile(const std::string& filename) {
+        std::ofstream file(filename);
+        if (!file) {
+            throw std::runtime_error("error opening file");
+        }
+        return file;
+    }
+
+    bool nandDataFileExist() {
+        std::ifstream file(NAND_DATA_FILE);
+        if (!file) return false;
+        return true;
+    }
+
+    void FillZeroDataToAllAddresses(std::ofstream& nandDataFile) {
+        for (uint32_t lba = 0; lba <= maxLbaOfDevice; ++lba) {
+            nandDataFile << std::hex << lba;
+            nandDataFile << SEPARATOR;
+            nandDataFile << std::setw(8) << std::setfill('0') << INIT_NAND_DATA;
+            nandDataFile << std::endl;
+        }
+    }
+
+    void FillChangeDatasToAllAddresses(std::ofstream& nandDataFile,
+        const std::vector<LbaEntry>& lbaTable) {
+        for (uint32_t lba = 0; lba <= maxLbaOfDevice; ++lba) {
+            nandDataFile << std::hex << lba;
+            nandDataFile << SEPARATOR;
+            nandDataFile << std::hex << std::setw(8) << std::setfill('0')
+                << lbaTable[lba].data;
+            nandDataFile << std::endl;
+        }
+    }
+
+    bool SuccessConvertToUINT(LbaEntry* splitDatas, std::string& addrStr,
+        std::string& dataStr) {
+        try {
+            (*splitDatas).address = std::stoul(addrStr, nullptr, 16);
+            (*splitDatas).data = std::stoul(dataStr, nullptr, 16);
+        }
+        catch (const std::exception& e) {
+            std::cerr << "Fail convert string to unsigned long :";
+            std::cerr << e.what() << std::endl;
+            return false;
+        }
+        return true;
+    }
+};

--- a/SSDSimulator/SSDSimulator/outputFile.h
+++ b/SSDSimulator/SSDSimulator/outputFile.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "fileIo.h"
+
+class OutputFile {
+public:
+    OutputFile() = default;
+
+    void updateOutputError() {
+        auto outputFile = openFile(OUTPUT_FILE);
+        outputFile << OUTPUT_ERROR;
+    }
+
+    void updateOutputWriteSuccess() {
+        auto outputFile = openFile(OUTPUT_FILE);
+    }
+
+    void updateOutputReadSuccess(uint32_t readData) {
+        auto outputFile = openFile(OUTPUT_FILE);
+        outputFile << "0x" << std::uppercase << std::hex << std::setw(8)
+            << std::setfill('0') << readData << std::endl;
+    }
+
+private:
+    const std::string OUTPUT_FILE = "ssd_output.txt";
+    const std::string OUTPUT_ERROR = "ERROR";
+
+    std::ofstream openFile(const std::string& filename) {
+        std::ofstream file(filename);
+        if (!file) {
+            throw std::runtime_error("error opening file");
+        }
+        return file;
+    }
+
+};


### PR DESCRIPTION
NAND, Output, 그리고 Buffer IO를 담당하는 
IOManager 내 기능들을 3개로 쪼갬

class IOManager {
    NANDFile;
    OutputFile;
    BufferFile;
}

legacy code와 호환 고려하여 사용중인 public API는 삭제하지 않았습니다