### PR TITLE
Write/Erase 간 buffering 동작 알고리즘 추가하였습니다.

### DIFF
--- a/SSDSimulator/SSDSimulator/bufferedCmdInfo.h
+++ b/SSDSimulator/SSDSimulator/bufferedCmdInfo.h
@@ -32,7 +32,6 @@ public:
 		address = 0;
 		type = CT_FLUSH;
 		isBufferingRequired = false;
-		isFlush = true;
 	}
 
 	SsdCmdInterface* getCmd() { return cmd; }
@@ -40,12 +39,8 @@ public:
 	//make field as needed
 	long address = 0;
 	long size = 1;
-	long valueToWrite = 0;
 	bool isBufferingRequired = false;
-	bool isFlush = false;
-	bool isRead;
+
 	commandType type;
-
 	SsdCmdInterface* cmd;
-
 };

--- a/SSDSimulator/SSDSimulator/bufferedCmdInfo.h
+++ b/SSDSimulator/SSDSimulator/bufferedCmdInfo.h
@@ -1,29 +1,36 @@
 #include "ssdCmdIncludes.h"
 
+enum commandType {
+	CT_READ = 1,
+	CT_WRITE = 2,
+	CT_ERASE = 3,
+	CT_FLUSH = 4,
+};
+
 class BufferedCmdInfo {
 public:
-
 	BufferedCmdInfo(SsdReadCmd* readCmd) : cmd(readCmd) {
 		address = readCmd->getAddress();
-		///...
 		isBufferingRequired = false;
+		type = CT_READ;
 	}
 
 	BufferedCmdInfo(SsdWriteCmd* writeCmd) : cmd(writeCmd) {
 		address = writeCmd->getAddress();
-		///...
+		type = CT_WRITE;
 		isBufferingRequired = true;
 	}
 
 	BufferedCmdInfo(SsdEraseCmd* eraseCmd) : cmd(eraseCmd) {
 		address = eraseCmd->getStartAddress();
-		///...
+		size = eraseCmd->getSize();
+		type = CT_ERASE;
 		isBufferingRequired = true;
 	}
 
 	BufferedCmdInfo(SsdFlushCmd* flushCmd) : cmd(flushCmd) {
 		address = 0;
-		///...
+		type = CT_FLUSH;
 		isBufferingRequired = false;
 		isFlush = true;
 	}
@@ -37,6 +44,7 @@ public:
 	bool isBufferingRequired = false;
 	bool isFlush = false;
 	bool isRead;
+	commandType type;
 
 	SsdCmdInterface* cmd;
 

--- a/SSDSimulator/SSDSimulator/cmdBuffer.cpp
+++ b/SSDSimulator/SSDSimulator/cmdBuffer.cpp
@@ -13,93 +13,94 @@ CommandBuffer::CommandBuffer(CommandBufferStorage& newStorage)
 }
 
 std::vector<SsdCmdInterface*> CommandBuffer::addBufferAndGetCmdToRun(SsdCmdInterface* newCmd) {
-	std::vector<SsdCmdInterface*> outstandingQ;
 	BufferedCmdInfo* bufferedInfo = newCmd->getBufferedCmdInfo();
 
-	if (!CheckBufferingCommand(bufferedInfo, outstandingQ, newCmd)) return outstandingQ;
-	
+	std::vector<SsdCmdInterface*> outstandingQ = GetNoBufferingCmd(bufferedInfo, newCmd);
+	if (outstandingQ.empty() == false) return outstandingQ;
+
 	if (bufferingQ.size() >= Q_SIZE_LIMIT_TO_FLUSH) {
-		auto tmp = popAllBuffer();  // 새 vector 생성
-		outstandingQ.clear();       // 기존 vector clear
-		outstandingQ.insert(outstandingQ.end(), tmp.begin(), tmp.end());
+		outstandingQ = popAllBufferToOutstandingQ();
+		filterInvalidWrites(outstandingQ);
 	}
 
-	std::vector<SsdCmdInterface*> cleanedQ(outstandingQ.begin(), outstandingQ.end());
-	filterInvalidWrites(cleanedQ);
-	outstandingQ = cleanedQ;
-
 	bufferingQ.push_back(bufferedInfo);
-	// need change buffer file name
-
 	storage.setBufferToStorage(bufferingQ);
 	return outstandingQ;
 }
 
-bool CommandBuffer::CheckBufferingCommand(BufferedCmdInfo* bufferedInfo, CmdQ_type& outstandingQ, SsdCmdInterface*& newCmd)
+std::vector<SsdCmdInterface*> CommandBuffer::GetNoBufferingCmd(BufferedCmdInfo* bufferedInfo, SsdCmdInterface*& newCmd)
 {
+	std::vector<SsdCmdInterface*> outstandingQ;
 	if (nullptr == bufferedInfo || false == bufferedInfo->isBufferingRequired) {
 		outstandingQ.push_back(newCmd);
-		return false;
 	}
-	return true;
+	return outstandingQ;
 }
 
 void CommandBuffer::filterInvalidWrites(std::vector<SsdCmdInterface*>& outstandingQ) {
-	// 1. erase 중복 처리 (앞에 있는 erase가 뒤에 포함되면 앞 erase 삭제)
 	std::vector<SsdCmdInterface*> erasesToRemove;
+	CheckLbaOverlapBothErases(outstandingQ, erasesToRemove);
+	removeFromOutstandingQ(outstandingQ, erasesToRemove);
+
+	std::vector<SsdCmdInterface*> writesToRemove;
+	CheckLbaOverlapWriteAndErase(outstandingQ, writesToRemove);
+	removeFromOutstandingQ(outstandingQ, writesToRemove);
+
+	CheckLbaOverlapBothWrites(outstandingQ);
+}
+
+void CommandBuffer::CheckLbaOverlapBothErases(CmdQ_type& outstandingQ, CmdQ_type& erasesToRemove)
+{
 	for (auto itCmd = outstandingQ.begin(); itCmd != outstandingQ.end(); ++itCmd) {
 		if ((*itCmd)->getBufferedCmdInfo()->type != CT_ERASE) continue;
 
 		uint32_t startFrontEraseAddress = (*itCmd)->getBufferedCmdInfo()->address;
 		uint32_t endFrontEraseAddress = startFrontEraseAddress + (*itCmd)->getBufferedCmdInfo()->size - 1;
 
-		for (auto itNextCmd = std::next(itCmd); itNextCmd != outstandingQ.end(); ++itNextCmd) {
-			if ((*itNextCmd)->getBufferedCmdInfo()->type != CT_ERASE) continue;
+		CompareWithOtherErases(itCmd, outstandingQ, startFrontEraseAddress, endFrontEraseAddress, erasesToRemove);
+	}
+}
+void CommandBuffer::CompareWithOtherErases(CmdQ_type::iterator& itCmd, CmdQ_type& outstandingQ, uint32_t startFrontEraseAddress, uint32_t endFrontEraseAddress, CmdQ_type& erasesToRemove)
+{
+	for (auto itNextCmd = std::next(itCmd); itNextCmd != outstandingQ.end(); ++itNextCmd) {
+		if ((*itNextCmd)->getBufferedCmdInfo()->type != CT_ERASE) continue;
 
-			auto* rearErase = dynamic_cast<SsdEraseCmd*>(*itNextCmd);
-			uint32_t startRearEraseAddress = rearErase->getStartAddress();
-			uint32_t endRearEraseAddress = startRearEraseAddress + rearErase->getSize() - 1;
+		auto* rearErase = dynamic_cast<SsdEraseCmd*>(*itNextCmd);
+		uint32_t startRearEraseAddress = rearErase->getStartAddress();
+		uint32_t endRearEraseAddress = startRearEraseAddress + rearErase->getSize() - 1;
 
-			if (startFrontEraseAddress >= startRearEraseAddress && endFrontEraseAddress <= endRearEraseAddress) {
-				erasesToRemove.push_back(*itCmd);
-				break; // 앞 erase는 하나만 삭제
-			}
+		if (startFrontEraseAddress >= startRearEraseAddress && endFrontEraseAddress <= endRearEraseAddress) {
+			erasesToRemove.push_back(*itCmd);
+			break;
 		}
 	}
+}
 
-	for (auto* cmdToRemove : erasesToRemove) {
-		auto it = std::find(outstandingQ.begin(), outstandingQ.end(), cmdToRemove);
-		if (it != outstandingQ.end()) {
-			outstandingQ.erase(it);
-		}
-	}
-
-	// 2. erase 앞에 있는 write 삭제 (erase 범위에 포함된 write 삭제)
-	std::vector<SsdCmdInterface*> writesToRemove;
+void CommandBuffer::CheckLbaOverlapWriteAndErase(CmdQ_type& outstandingQ, CmdQ_type& writesToRemove)
+{
 	for (auto itCommand = outstandingQ.begin(); itCommand != outstandingQ.end(); ++itCommand) {
 		if ((*itCommand)->getBufferedCmdInfo()->type != CT_ERASE) continue;
 
 		uint32_t startEraseAddress = (*itCommand)->getBufferedCmdInfo()->address;
 		uint32_t endEraseAddress = startEraseAddress + (*itCommand)->getBufferedCmdInfo()->size - 1;
 
-		for (auto itNextCmd = outstandingQ.begin(); itNextCmd != itCommand; ++itNextCmd) {
-			if ((*itNextCmd)->getBufferedCmdInfo()->type == CT_WRITE) {
-				uint32_t writeAddress = (*itNextCmd)->getBufferedCmdInfo()->address;
-				if (writeAddress >= startEraseAddress && writeAddress <= endEraseAddress) {
-					writesToRemove.push_back(*itNextCmd);
-				}
+		CompareWithWrites(outstandingQ, itCommand, startEraseAddress, endEraseAddress, writesToRemove);
+	}
+}
+void CommandBuffer::CompareWithWrites(CmdQ_type& outstandingQ, CmdQ_type::iterator& itCommand, uint32_t startEraseAddress, uint32_t endEraseAddress, CmdQ_type& writesToRemove)
+{
+	for (auto itNextCmd = outstandingQ.begin(); itNextCmd != itCommand; ++itNextCmd) {
+		if ((*itNextCmd)->getBufferedCmdInfo()->type == CT_WRITE) {
+			uint32_t writeAddress = (*itNextCmd)->getBufferedCmdInfo()->address;
+			if (writeAddress >= startEraseAddress && writeAddress <= endEraseAddress) {
+				writesToRemove.push_back(*itNextCmd);
 			}
 		}
 	}
+}
 
-	for (auto* cmdToRemove : writesToRemove) {
-		auto it = std::find(outstandingQ.begin(), outstandingQ.end(), cmdToRemove);
-		if (it != outstandingQ.end()) {
-			outstandingQ.erase(it);
-		}
-	}
-
-	// 3. write 중복 주소 처리 (역순 index 순회, 앞쪽 write 삭제)
+void CommandBuffer::CheckLbaOverlapBothWrites(CmdQ_type& outstandingQ)
+{
 	std::unordered_set<uint32_t> seenAddresses;
 	for (int i = static_cast<int>(outstandingQ.size()) - 1; i >= 0; --i) {
 		auto* cmd = outstandingQ[i];
@@ -115,7 +116,17 @@ void CommandBuffer::filterInvalidWrites(std::vector<SsdCmdInterface*>& outstandi
 	}
 }
 
-vector<SsdCmdInterface*> CommandBuffer::popAllBuffer() {
+void CommandBuffer::removeFromOutstandingQ(CmdQ_type& outstandingQ, CmdQ_type& erasesToRemove)
+{
+	for (auto* cmdToRemove : erasesToRemove) {
+		auto it = std::find(outstandingQ.begin(), outstandingQ.end(), cmdToRemove);
+		if (it != outstandingQ.end()) {
+			outstandingQ.erase(it);
+		}
+	}
+}
+
+vector<SsdCmdInterface*> CommandBuffer::popAllBufferToOutstandingQ() {
 	std::vector<SsdCmdInterface*> outstandingQ;
 	for (auto bufferedInfo : bufferingQ) {
 		outstandingQ.push_back(bufferedInfo->getCmd());
@@ -127,10 +138,12 @@ vector<SsdCmdInterface*> CommandBuffer::popAllBuffer() {
 
 void CommandBuffer::ClearBufferingQ() {
 	for (auto* cmd : bufferingQ) {
-		delete cmd;  // 각각의 포인터가 가리키는 실제 객체 삭제
+		delete cmd;
 	}
 	bufferingQ.clear();
 }
+
+/* CommandBufferStorage class functions */
 
 vector<BufferedCmdInfo*> CommandBufferStorage::getBufferFromStorage() {
 	vector<BufferedCmdInfo*> result;

--- a/SSDSimulator/SSDSimulator/cmdBuffer.h
+++ b/SSDSimulator/SSDSimulator/cmdBuffer.h
@@ -9,8 +9,8 @@ typedef vector<SsdCmdInterface*>CmdQ_type;
 class CommandBufferStorage {
 public:
 	virtual vector<BufferedCmdInfo*> getBufferFromStorage();
-	bool isValidFileName(std::string& line, int fileIdx);
 	virtual void setBufferToStorage(vector<BufferedCmdInfo*> cmdQ);
+	bool isValidFileName(std::string& line, int fileIdx);
 private:
 	std::vector<std::string> splitByUnderBar(const std::string& str);
 	bool checkRemainIsEmpty(vector<std::string> fileNames, int startCheckIdx);
@@ -26,9 +26,8 @@ public:
 
 	CommandBuffer(CommandBufferStorage& stroage);
 	CmdQ_type  addBufferAndGetCmdToRun(SsdCmdInterface* newCmd);
-	CmdQ_type  popAllBuffer();
+	CmdQ_type  popAllBufferToOutstandingQ();
 	void filterInvalidWrites(std::vector<SsdCmdInterface*>& outstandingQ);
-	void removeFromOutstandingQ(CmdQ_type& erasesToRemove, CmdQ_type& outstandingQ);
 	void ClearBufferingQ();
 
 protected:
@@ -38,6 +37,12 @@ protected:
 	static const int Q_SIZE_LIMIT_TO_FLUSH = 5;
 
 private:
-	bool CheckBufferingCommand(BufferedCmdInfo* bufferedInfo, CmdQ_type& resultQ, SsdCmdInterface*& newCmd);
+	std::vector<SsdCmdInterface*> GetNoBufferingCmd(BufferedCmdInfo* bufferedInfo, SsdCmdInterface*& newCmd);
+	void CheckLbaOverlapBothErases(CmdQ_type& outstandingQ, CmdQ_type& erasesToRemove);
+	void CheckLbaOverlapWriteAndErase(CmdQ_type& outstandingQ, CmdQ_type& writesToRemove);
+	void CheckLbaOverlapBothWrites(CmdQ_type& outstandingQ);
+	void CompareWithOtherErases(CmdQ_type::iterator& itCmd, CmdQ_type& outstandingQ, uint32_t startFrontEraseAddress, uint32_t endFrontEraseAddress, CmdQ_type& erasesToRemove);
+	void CompareWithWrites(CmdQ_type& outstandingQ, CmdQ_type::iterator& itCommand, uint32_t startEraseAddress, uint32_t endEraseAddress, CmdQ_type& writesToRemove);
+	void removeFromOutstandingQ(CmdQ_type& outstandingQ, CmdQ_type& erasesToRemove);
 };
 

--- a/SSDSimulator/SSDSimulator/cmdBuffer.h
+++ b/SSDSimulator/SSDSimulator/cmdBuffer.h
@@ -27,7 +27,9 @@ public:
 	CommandBuffer(CommandBufferStorage& stroage);
 	CmdQ_type  addBufferAndGetCmdToRun(SsdCmdInterface* newCmd);
 	CmdQ_type  popAllBuffer();
-
+	void filterInvalidWrites(std::vector<SsdCmdInterface*>& outstandingQ);
+	void removeFromOutstandingQ(CmdQ_type& erasesToRemove, CmdQ_type& outstandingQ);
+	void ClearBufferingQ();
 
 protected:
 	vector<BufferedCmdInfo*> bufferingQ;


### PR DESCRIPTION
1) Erase끼리 비교 (앞에 들어온 erase의 address가 뒤에 들어온 erase의 address 범위에 완전히 속하면 outstandingQ에서 제거)
2) Erase와 앞에 들어온 Write와 비교 (Write가 Erase의 address에 속하면 outstandingQ에서 제거)
3) Write끼리 비교 (뒤에 들어온 Write와 앞에 들어온 Write의 주소가 같으면 앞 Write를 outstandingQ에서 제거)
